### PR TITLE
Corrige três problemas do DDL do banco

### DIFF
--- a/ddl.sql
+++ b/ddl.sql
@@ -6,7 +6,7 @@
 CREATE TABLE IF NOT EXISTS author
 (
     id         SERIAL PRIMARY KEY,
-    name       VARCHAR(100) NOT NULL, 
+    name       VARCHAR(100) NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
@@ -14,7 +14,7 @@ CREATE TABLE IF NOT EXISTS author
 CREATE TABLE IF NOT EXISTS genre
 (
     id   SERIAL PRIMARY KEY,
-    name VARCHAR(100) UNIQUE NOT NULL 
+    name VARCHAR(100) UNIQUE NOT NULL
 );
 
 -- ===========================
@@ -101,13 +101,13 @@ CREATE TABLE IF NOT EXISTS user_account
 (
     id              SERIAL PRIMARY KEY,
     name            VARCHAR(150)        NOT NULL,
-    phone           VARCHAR(20) UNIQUE  NOT NULL,                           
+    phone           VARCHAR(20) UNIQUE  NOT NULL,
     email           VARCHAR(150) UNIQUE NOT NULL,
     password_hash   VARCHAR(255)        NOT NULL,
     created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    updated_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,                    
+    updated_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     is_active       BOOLEAN   DEFAULT TRUE,
-    fk_account_role INTEGER REFERENCES account_role (id) ON DELETE RESTRICT 
+    fk_account_role INTEGER REFERENCES account_role (id) ON DELETE RESTRICT
 );
 
 -- Trigger to update `updated_at` on user account updates
@@ -140,7 +140,7 @@ CREATE TABLE IF NOT EXISTS reservation
     id            SERIAL PRIMARY KEY,
     reserved_at   TIMESTAMP          DEFAULT CURRENT_TIMESTAMP,
     expires_at    TIMESTAMP GENERATED ALWAYS AS ( reserved_at + INTERVAL '24 hours') STORED,
-    borrowed_days INTEGER NOT NULL CHECK ( borrowed_days <= 90 ),          
+    borrowed_days INTEGER NOT NULL CHECK ( borrowed_days <= 90 ),
     status        reservation_status DEFAULT 'pending',
     fk_user_id    INTEGER REFERENCES user_account (id) ON DELETE CASCADE,
     fk_admin_id   INTEGER REFERENCES user_account (id) ON DELETE SET NULL,

--- a/ddl.sql
+++ b/ddl.sql
@@ -40,7 +40,7 @@ CREATE TABLE IF NOT EXISTS book_stock
     status     book_stock_status DEFAULT 'available',
     code       INTEGER NOT NULL UNIQUE,
     created_at TIMESTAMP         DEFAULT CURRENT_TIMESTAMP,
-    fk_book_id INTEGER REFERENCES book (id)
+    fk_book_id INTEGER REFERENCES book (id) ON DELETE CASCADE
 );
 
 CREATE OR REPLACE FUNCTION prevent_book_stock_delete_if_borrowed()

--- a/ddl.sql
+++ b/ddl.sql
@@ -50,6 +50,7 @@ BEGIN
     IF OLD.status = 'borrowed' THEN
         RAISE EXCEPTION 'Cannot delete book_stock unless the status is ''available'' or ''missing''.';
     END IF;
+    RETURN OLD;
 END;
 $$ LANGUAGE plpgsql;
 
@@ -220,6 +221,7 @@ BEGIN
         RAISE EXCEPTION 'Cannot delete loan unless the status is ''returned''.';
 
     END IF;
+    RETURN OLD;
 END;
 $$ LANGUAGE plpgsql;
 


### PR DESCRIPTION
Haviam três problemas no DDL do banco:

1. Falta do `ON DELETE CASCADE` na tabela `book_stock`;
2. Falta do `RETURN OLD` na função `prevent_loan_delete_if_active`;
3. Falta do `RETURN OLD` na função `prevent_book_stock_delete_if_borrowed`.

Este pull request corrige estes problemas, e ainda tira uns espaçamentos.