### PR TITLE
Corrige rota de estoque que não recebia ID

### DIFF
--- a/controller/book_controller.go
+++ b/controller/book_controller.go
@@ -177,13 +177,24 @@ func (bc *bookController) UpdateStockStatus(c *gin.Context) {
 }
 
 func (bc *bookController) RemoveStock(c *gin.Context) {
-	id, err := strconv.Atoi(c.Param("id"))
+	var err error
+	var bookId int
+
+	bookId, err = strconv.Atoi(c.Param("id"))
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid book stock Id"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid book Id"})
 		return
 	}
 
-	if err := bc.useCase.RemoveStock(id); err != nil {
+	var stockId int
+
+	stockId, err = strconv.Atoi(c.Param("stock-id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid stock Id"})
+		return
+	}
+
+	if err := bc.useCase.RemoveStock(stockId, &bookId); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}

--- a/repository/book_repository.go
+++ b/repository/book_repository.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"go-api/model"
 	"strconv"
@@ -15,7 +16,7 @@ type BookRepository interface {
 	AddStock(code, bookId int) (*model.BookStock, error)
 	GetStock(code *int, bookId int) (*[]model.BookStock, error)
 	UpdateStockStatus(id int, status string) error
-	RemoveStock(id int) error
+	RemoveStock(id int, bookId *int) error
 }
 
 type bookRepository struct {
@@ -279,16 +280,29 @@ func (br *bookRepository) UpdateStockStatus(id int, status string) error {
 	panic("implement me")
 }
 
-func (br *bookRepository) RemoveStock(id int) error {
+func (br *bookRepository) RemoveStock(id int, bookId *int) error {
 	query := `
         DELETE FROM book_stock 
-        WHERE id = $1 
-        RETURNING id;
+        WHERE id = $1
     `
 
+	var args []interface{}
+	args = append(args, id)
+
+	if bookId != nil {
+		query += ` AND fk_book_id = $2`
+		args = append(args, bookId)
+	}
+
+	query += ` RETURNING id;`
+
 	var deletedBookStockId int
-	err := br.db.QueryRow(query, id).Scan(&deletedBookStockId)
+
+	err := br.db.QueryRow(query, args...).Scan(&deletedBookStockId)
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("book stock with id %d not found", id)
+		}
 		return fmt.Errorf("error deleting book stock: %v", err)
 	}
 

--- a/routes/book_routes.go
+++ b/routes/book_routes.go
@@ -28,8 +28,8 @@ func BookRoutes(rg *gin.RouterGroup) {
 		{
 			stock.POST("/add", bookController.AddStock)
 			stock.GET("/", bookController.GetStock)
-			stock.PUT("/update-status", bookController.UpdateStockStatus)
-			stock.DELETE("/remove", bookController.RemoveStock)
+			stock.PUT("/update-status/:stock-id", bookController.UpdateStockStatus)
+			stock.DELETE("/remove/:stock-id", bookController.RemoveStock)
 		}
 	}
 }

--- a/usecase/book_usecase.go
+++ b/usecase/book_usecase.go
@@ -13,7 +13,7 @@ type BookUseCase interface {
 	AddStock(code, bookId int) (*model.BookStock, error)
 	GetStock(code *int, bookId int) (*[]model.BookStock, error)
 	UpdateStockStatus(id int, status string) error
-	RemoveStock(id int) error
+	RemoveStock(id int, bookId *int) error
 }
 
 type bookUseCase struct {
@@ -53,6 +53,6 @@ func (uc *bookUseCase) UpdateStockStatus(id int, status string) error {
 	panic("implement me")
 }
 
-func (uc *bookUseCase) RemoveStock(id int) error {
-	return uc.repository.RemoveStock(id)
+func (uc *bookUseCase) RemoveStock(id int, bookId *int) error {
+	return uc.repository.RemoveStock(id, bookId)
 }


### PR DESCRIPTION
As rotas para verificar o estoque do produto não estavam recebendo o id do produto em estoque, recebiam o Id do livro, levando a incoerências na query.

