### PR TITLE
Adiciona rotas de busca de reserva por usuário e cancelamento de reserva por usuário 

### DIFF
--- a/routes/user_routes.go
+++ b/routes/user_routes.go
@@ -30,6 +30,12 @@ func UserRoutes(rg *gin.RouterGroup) {
 		users.PUT("/activate/:id", userController.ToggleUser("activate"))
 		users.PUT("/deactivate/:id", userController.ToggleUser("deactivate"))
 		users.DELETE("/delete/:id", userController.DeleteUser)
+
+		reservations := users.Group("/:id/reservations")
+		{
+			reservations.GET("/", userController.GetUserReservations)
+			reservations.PUT("/cancel/:reservation-id", userController.CancelUserReservation)
+		}
 	}
 
 	user := rg.Group("/user")
@@ -40,6 +46,13 @@ func UserRoutes(rg *gin.RouterGroup) {
 			middleware.RoleRequired("admin"),
 			userController.Register,
 		)
-		user.GET("/loans",middleware.JWTAuthMiddleware, userController.GetUserLoans)
+
+		reservations := user.Group("/reservations", middleware.JWTAuthMiddleware)
+		{
+			reservations.GET("/", userController.GetLoggedUserReservations)
+			reservations.PUT("/:id/cancel", userController.CancelLoggedUserReservation)
+		}
+
+		user.GET("/loans", middleware.JWTAuthMiddleware, userController.GetUserLoans)
 	}
 }

--- a/usecase/user_usecase.go
+++ b/usecase/user_usecase.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"errors"
+	"fmt"
 	"go-api/model"
 	"go-api/model/user"
 	"go-api/repository"
@@ -17,6 +18,8 @@ type UserUseCase interface {
 	ActivateUser(id int) error
 	DeactivateUser(id int) error
 	DeleteUser(id int) error
+	GetUserReservations(id int) ([]*model.Reservation, error)
+	CancelUserReservation(id, reservationId int, adminId *int) error
 }
 
 type userUseCase struct {
@@ -72,4 +75,17 @@ func (uu *userUseCase) DeactivateUser(id int) error {
 
 func (uu *userUseCase) DeleteUser(id int) error {
 	return uu.userRepo.DeleteUser(id)
+}
+
+func (uu *userUseCase) CancelUserReservation(id, reservationId int, adminId *int) error {
+	res, err := uu.userRepo.GetUserReservationById(id, reservationId)
+	if err != nil {
+		return err
+	}
+
+	if res.Status != model.Pending {
+		return fmt.Errorf("cannot cancel user reservation unless its status is 'pending'. Current status: '%s'", res.Status)
+	}
+
+	return uu.userRepo.CancelUserReservation(id, reservationId, adminId)
 }


### PR DESCRIPTION
Implementa rotas para busca e cancelamento de reservas de usuário.

- `GetUserReservations`: Retorna todas as reserva de um usuário, usa `params`, só pode ser acessado por usuário `admin`;
- `GetLoggedUserReservations`: Retorna todas as reservas do usuário logado, usa `Header`;

- `CancelUserReservation`: Cancela a reserva de um usuário, usa `params` para pegar o Id do usuário e o Id da reserva, depois usa `Header` para pegar o Id do admin, só pode ser acessado por usuário `admin`;

- `CancelLoggedUserReservation`: Cancela a reserva do usuário logado, usa `params` para pegar o Id da reserva, depois usa `Header` para pegar o Id do usuário.