### PR TITLE
Remove parâmetro 'book_codes' da rota books/create

### DIFF
--- a/controller/book_controller.go
+++ b/controller/book_controller.go
@@ -32,11 +32,10 @@ func NewBookController(useCase usecase.BookUseCase) BookController {
 // CreateBook recebe um input JSON através do gin.Context e tenta criar um livro.
 func (bc *bookController) CreateBook(c *gin.Context) {
 	var i struct {
-		Title     string `json:"title" binding:"required"`
-		Synopsis  string `json:"synopsis" binding:"required"`
-		BookCodes []int  `json:"book_codes"`
-		AuthorId  int    `json:"author_id" binding:"required"`
-		GenreIds  []int  `json:"genre_ids" binding:"required"`
+		Title    string `json:"title" binding:"required"`
+		Synopsis string `json:"synopsis" binding:"required"`
+		AuthorId int    `json:"author_id" binding:"required"`
+		GenreIds []int  `json:"genre_ids" binding:"required"`
 	}
 
 	if err := c.ShouldBindJSON(&i); err != nil {
@@ -44,11 +43,7 @@ func (bc *bookController) CreateBook(c *gin.Context) {
 		return
 	}
 
-	if i.BookCodes == nil {
-		i.BookCodes = []int{}
-	}
-
-	book, err := bc.useCase.CreateBook(i.Title, i.Synopsis, i.BookCodes, i.AuthorId, i.GenreIds)
+	book, err := bc.useCase.CreateBook(i.Title, i.Synopsis, i.AuthorId, i.GenreIds)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -195,12 +195,6 @@
                                     "value": {
                                         "title": "Navio",
                                         "synopsis": "Navio voador",
-                                        "book_codes": [
-                                            1,
-                                            2,
-                                            3,
-                                            4
-                                        ],
                                         "author_id": 3,
                                         "genre_ids": [
                                             1,
@@ -550,7 +544,7 @@
                         "type": "string"
                     },
                     "phone":{
-                        "type": "string" 
+                        "type": "string"
                     },
                     "email":{
                         "type": "string"
@@ -582,12 +576,6 @@
                     },
                     "synopsis": {
                         "type": "string"
-                    },
-                    "book_codes": {
-                        "type": "array",
-                        "items": {
-                            "type": "integer"
-                        }
                     },
                     "author_id": {
                         "type": "integer"

--- a/usecase/book_usecase.go
+++ b/usecase/book_usecase.go
@@ -6,7 +6,7 @@ import (
 )
 
 type BookUseCase interface {
-	CreateBook(title, synopsis string, bookCodes []int, authorId int, genreIds []int) (*model.Book, error)
+	CreateBook(title, synopsis string, authorId int, genreIds []int) (*model.Book, error)
 	GetBooks(title, author string, genres []string) (*[]model.Book, error)
 	GetBookById(id int) (*model.Book, error)
 	UpdateBook(id int, title, synopsis string, authorId int) error
@@ -25,8 +25,8 @@ func NewBookUseCase(repository repository.BookRepository) BookUseCase {
 	return &bookUseCase{repository: repository}
 }
 
-func (uc *bookUseCase) CreateBook(title, synopsis string, bookCodes []int, authorId int, genreIds []int) (*model.Book, error) {
-	return uc.repository.CreateBook(title, synopsis, bookCodes, authorId, genreIds)
+func (uc *bookUseCase) CreateBook(title, synopsis string, authorId int, genreIds []int) (*model.Book, error) {
+	return uc.repository.CreateBook(title, synopsis, authorId, genreIds)
 }
 
 func (uc *bookUseCase) GetBooks(title, author string, genres []string) (*[]model.Book, error) {


### PR DESCRIPTION
Se um livro fosse duplicado, aconteceria um erro, e se ocorresse um erro, o livro seria criado sem estoque e sem gêneros, o que não é adequado.