### PR TITLE
Fixes the loan finish date issue

### DIFF
--- a/controller/loan_controller.go
+++ b/controller/loan_controller.go
@@ -1,9 +1,7 @@
 package controller
 
 import (
-	"fmt"
 	"github.com/gin-gonic/gin"
-	"go-api/model"
 	"go-api/usecase"
 	"net/http"
 	"strconv"
@@ -11,7 +9,7 @@ import (
 
 type LoanController interface {
 	CreateLoan(c *gin.Context)
-	UpdateLoan(c *gin.Context)
+	FinishLoan(c *gin.Context)
 }
 
 type loanController struct {
@@ -58,19 +56,10 @@ func (lc *loanController) CreateLoan(c *gin.Context) {
 	c.JSON(http.StatusCreated, loan)
 }
 
-func (lc *loanController) UpdateLoan(c *gin.Context) {
-	loanIDStr := c.Param("id")
-	loanId, err := strconv.Atoi(loanIDStr)
-	fmt.Printf("Loan ID: %d\n", loanId)
-
+func (lc *loanController) FinishLoan(c *gin.Context) {
+	loanId, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid loan ID"})
-		return
-	}
-
-	var request model.LoanUpdateRequest
-	if err := c.ShouldBindJSON(&request); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
 		return
 	}
 
@@ -87,11 +76,11 @@ func (lc *loanController) UpdateLoan(c *gin.Context) {
 		return
 	}
 
-	err = lc.loanUseCase.UpdateLoan(request, adminId, loanId)
+	err = lc.loanUseCase.FinishLoan(loanId, adminId)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"message": "loan updated successfully"})
+	c.JSON(http.StatusOK, gin.H{"message": "loan finished successfully"})
 }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -953,6 +953,36 @@
           }
         }
       }
+    },
+    "/loans/finish-loan/{id}": {
+      "put": {
+        "summary": "Finaliza um empréstimo (admin)",
+        "description": "Finaliza um empréstimo ativo, fazendo que o livro emprestado retorne ao estoque.",
+        "tags": [
+          "Empréstimos"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Id do empréstimo",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Sucesso"
+          }
+        }
+      }
     }
   },
   "components": {

--- a/repository/loan_repository.go
+++ b/repository/loan_repository.go
@@ -10,6 +10,7 @@ type LoanRepository interface {
 	CreateLoan(reservationId, bookStockId, borrowedDays int) (*model.Loan, error)
 	GetLoanById(id int) (*model.Loan, error)
 	UpdateLoan(loan *model.Loan) error
+	FinishLoan(id, adminId int) error
 }
 
 type loanRepository struct {
@@ -65,6 +66,14 @@ func (lr *loanRepository) UpdateLoan(loan *model.Loan) error {
 	_, err := lr.db.Exec(query, loan.ReturnedAt, loan.AdminId, loan.Status, loan.Id)
 	if err != nil {
 		return fmt.Errorf("failed to update loan: %w", err)
+	}
+	return nil
+}
+func (lr *loanRepository) FinishLoan(id, adminId int) error {
+	query := `UPDATE loan SET returned_at = CURRENT_TIMESTAMP, status = 'returned', fk_admin_id = $1 WHERE id = $2`
+	_, err := lr.db.Exec(query, adminId, id)
+	if err != nil {
+		return fmt.Errorf("failed to finish loan: %w", err)
 	}
 	return nil
 }

--- a/routes/loan_routes.go
+++ b/routes/loan_routes.go
@@ -24,6 +24,6 @@ func LoanRoutes(rg *gin.RouterGroup) {
 	loan := rg.Group("/loans", middleware.JWTAuthMiddleware)
 	{
 		loan.POST("/create", middleware.RoleRequired("admin"), loanController.CreateLoan)
-		loan.PUT("/finish-loan/:id", middleware.RoleRequired("admin"), loanController.UpdateLoan)
+		loan.PUT("/finish-loan/:id", middleware.RoleRequired("admin"), loanController.FinishLoan)
 	}
 }

--- a/usecase/loan_usecase.go
+++ b/usecase/loan_usecase.go
@@ -10,6 +10,7 @@ import (
 type LoanUseCase interface {
 	CreateLoanAndUpdateReservation(reservationId, bookStockId, adminId int) (*model.Loan, error)
 	UpdateLoan(request model.LoanUpdateRequest, adminID int, loanId int) error
+	FinishLoan(loanId, adminId int) error
 }
 
 type loanUseCase struct {
@@ -92,6 +93,24 @@ func (lu *loanUseCase) UpdateLoan(request model.LoanUpdateRequest, adminID int, 
 	err = lu.loanRepo.UpdateLoan(loan)
 	if err != nil {
 		return fmt.Errorf("failed to update loan: %w", err)
+	}
+
+	return nil
+}
+
+func (lu *loanUseCase) FinishLoan(loanId, adminId int) error {
+	loan, err := lu.loanRepo.GetLoanById(loanId)
+	if err != nil {
+		return err
+	}
+
+	if loan.Status != model.LoanBorrowed {
+		return fmt.Errorf("loan is not borrowed")
+	}
+
+	err = lu.loanRepo.FinishLoan(loanId, adminId)
+	if err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
I've just made the `returned_at` variable to be set as `CURRENT_TIMESTAMP` instead of relying on Go's `time.Now()` method, which means the database is now responsible for determining it.

I've also added finish-loan to the swagger.